### PR TITLE
Update reference to core profile

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -18,7 +18,7 @@ publisher:
 
 meta:
   profile:
-        - http://smart.who.int/smart-base/ImplementationGuide-SGImplementationGuide
+        - http://smart.who.int/base/StructureDefinition/SGImplementationGuide
 
 pages:
   index.md:


### PR DESCRIPTION
@c-corman @litlfred this is about a small QA error that is not relevant for DAKs. It just clears up an error in the QA report.  if you want not to merge for 1.0.0 it doesn't impact the outcome. but may as well merge if still ok.